### PR TITLE
Fix issue #1

### DIFF
--- a/src/DateWithoutTime.ts
+++ b/src/DateWithoutTime.ts
@@ -2,7 +2,7 @@ export class DateWithoutTime {
   utcMidnightDateObj: Date
   constructor(dateOrYearOrDaysSinceEpoch?: any, month?: number, day?: number) {
     if (!isNaN(dateOrYearOrDaysSinceEpoch)) {
-      if (month) this.utcMidnightDateObj = new Date(Date.UTC(dateOrYearOrDaysSinceEpoch, month, day))
+      if (month || month === 0) this.utcMidnightDateObj = new Date(Date.UTC(dateOrYearOrDaysSinceEpoch, month, day))
       else this.utcMidnightDateObj = new Date(dateOrYearOrDaysSinceEpoch * 86_400_000)
     } else {
       // if no date supplied, use Now.


### PR DESCRIPTION
As mentioned in Issue #1 : JS-Month is zero-based leading to January being a falsy value, hence a simple if(month) check will lead to unwanted results.  If (month || month === 0) will assure that 0 (=January) will be a valid month and leave any other falsy values (null, undefined, "" etc) untouched